### PR TITLE
Investigar inconsistencia de cartas de usuario

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1489,7 +1489,7 @@
                     userCardsCache = [];
                     
                     querySnapshot.forEach(doc => {
-                        userCardsCache.push(doc.data());
+                        userCardsCache.push({ id: doc.id, ...doc.data() });
                     });
                 } catch (error) {
                     console.error('Error cargando cartas:', error);
@@ -6101,7 +6101,7 @@
                     userCardsCache = [];
 
                     querySnapshot.forEach(doc => {
-                        userCardsCache.push(doc.data());
+                        userCardsCache.push({ id: doc.id, ...doc.data() });
                     });
                 }
 

--- a/html/index_original.html
+++ b/html/index_original.html
@@ -1399,7 +1399,7 @@
                     userCardsCache = [];
                     
                     querySnapshot.forEach(doc => {
-                        userCardsCache.push(doc.data());
+                        userCardsCache.push({ id: doc.id, ...doc.data() });
                     });
                 } catch (error) {
                     console.error('Error cargando cartas:', error);

--- a/html/index_with_embedded_code.html
+++ b/html/index_with_embedded_code.html
@@ -1399,7 +1399,7 @@
                     userCardsCache = [];
                     
                     querySnapshot.forEach(doc => {
-                        userCardsCache.push(doc.data());
+                        userCardsCache.push({ id: doc.id, ...doc.data() });
                     });
                 } catch (error) {
                     console.error('Error cargando cartas:', error);

--- a/js/main.js
+++ b/js/main.js
@@ -1327,7 +1327,7 @@ window.addFromMyCards = async function(type) {
             userCardsCache = [];
             
             querySnapshot.forEach(doc => {
-                userCardsCache.push(doc.data());
+                userCardsCache.push({ id: doc.id, ...doc.data() });
             });
         } catch (error) {
             console.error('Error cargando cartas:', error);
@@ -3647,7 +3647,7 @@ async function loadMyCollection(userId) {
         userCardsCache = [];
 
         querySnapshot.forEach(doc => {
-            userCardsCache.push(doc.data());
+            userCardsCache.push({ id: doc.id, ...doc.data() });
         });
 
         // Aplicar filtros


### PR DESCRIPTION
Include document ID when caching user cards to resolve inconsistency between 'My Cards' and profile display.

The `loadMyCollection` function was storing card data in `userCardsCache` without the Firestore document `id`, unlike `loadProfileStats` and `cards.js`. This caused "My Cards" to not display saved cards correctly. This PR ensures all cached cards include their `id` for consistent behavior across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-88d10659-dc79-4796-995a-a3fa1ba49259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88d10659-dc79-4796-995a-a3fa1ba49259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

